### PR TITLE
1.3.1 Updates

### DIFF
--- a/files/js/editor_element.js
+++ b/files/js/editor_element.js
@@ -19,6 +19,9 @@
             var tabs = this.$('.tabbed-box-tab');
             var content = this.$('.tabbed-box-content');
 
+            // if we have any iframes, we get an overlay...
+            this.$el.children('.platform-element-overlay').hide();
+
             // optimization
             this.scrollArrowLeft = this.$('.scrollArrow-left');
             this.scrollArrowRight = this.$('.scrollArrow-right');

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "manifest": "1",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "locale": {
     "default": "en-us",
     "supported": [
@@ -11,7 +11,7 @@
     {
       "name": "Tabs",
       "path": "files",
-      "version": "1.3.0",
+      "version": "1.3.1",
       "settings": {
         "config": {},
         "properties": [


### PR DESCRIPTION
Changes:

* When a user has a tab w/ an iframe-based element (YouTube, document, etc), a platform-element-overlay gets assigned to the tab itself, because the editor thinks that it needs to cover up click events. Unfortunately, this also turns off the click event handlers that the tabs use, because the overlay takes up the entire element. This fixes that.